### PR TITLE
Debug server routes in bismarck-game

### DIFF
--- a/bismarck-game/backend/config.json
+++ b/bismarck-game/backend/config.json
@@ -1,9 +1,9 @@
 {
   "server": {
     "address": ":8080",
-    "read_timeout": 30,
-    "write_timeout": 30,
-    "idle_timeout": 60
+    "read_timeout": "30s",
+    "write_timeout": "30s",
+    "idle_timeout": "60s"
   },
   "database": {
     "host": "localhost",
@@ -24,10 +24,10 @@
   },
   "game": {
     "max_players": 2,
-    "turn_duration": 30,
-    "game_start_delay": 10,
+    "turn_duration": "30s",
+    "game_start_delay": "10s",
     "max_games": 100,
-    "cleanup_interval": 300
+    "cleanup_interval": "300s"
   },
   "log": {
     "level": "debug",

--- a/bismarck-game/backend/internal/config/utils.go
+++ b/bismarck-game/backend/internal/config/utils.go
@@ -34,10 +34,10 @@ func GetDefaultConfigPath() string {
 func GetTestConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			Address:      ":0", // случайный порт
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 5 * time.Second,
-			IdleTimeout:  30 * time.Second,
+            Address:      ":0", // случайный порт
+            ReadTimeout:  JSONDuration(5 * time.Second),
+            WriteTimeout: JSONDuration(5 * time.Second),
+            IdleTimeout:  JSONDuration(30 * time.Second),
 		},
 		Database: DatabaseConfig{
 			Host:     "localhost",
@@ -51,17 +51,17 @@ func GetTestConfig() *Config {
 			Address: "localhost:6379",
 			DB:      1, // отдельная БД для тестов
 		},
-		JWT: JWTConfig{
-			Secret:     "test-secret-key",
-			Expiration: 1 * time.Hour,
-		},
-		Game: GameConfig{
-			MaxPlayers:      2,
-			TurnDuration:    10 * time.Second,
-			GameStartDelay:  2 * time.Second,
-			MaxGames:        10,
-			CleanupInterval: 30 * time.Second,
-		},
+        JWT: JWTConfig{
+            Secret:     "test-secret-key",
+            Expiration: JSONHours(1 * time.Hour),
+        },
+        Game: GameConfig{
+            MaxPlayers:      2,
+            TurnDuration:    JSONDuration(10 * time.Second),
+            GameStartDelay:  JSONDuration(2 * time.Second),
+            MaxGames:        10,
+            CleanupInterval: JSONDuration(30 * time.Second),
+        },
 		Log: LogConfig{
 			Level:  "error", // минимум логов в тестах
 			Format: "text",

--- a/bismarck-game/backend/internal/server/server.go
+++ b/bismarck-game/backend/internal/server/server.go
@@ -26,6 +26,7 @@ func New(cfg *config.Config) *Server {
 }
 
 func (s *Server) setupRoutes() {
+    s.router.Use(s.loggingMiddleware)
 	s.router.HandleFunc("/", s.handleRoot).Methods("GET")
 	s.router.HandleFunc("/health", s.handleHealth).Methods("GET")
 	s.router.NotFoundHandler = http.HandlerFunc(s.handleNotFound)
@@ -38,9 +39,10 @@ func (s *Server) setupRoutes() {
 func (s *Server) Start() error {
 	srv := &http.Server{
 		Addr:         s.config.Server.Address,
-		Handler:      s.router,
-		ReadTimeout:  s.config.Server.ReadTimeout,
-		WriteTimeout: s.config.Server.WriteTimeout,
+        Handler:      s.router,
+        ReadTimeout:  s.config.Server.ReadTimeout.Duration(),
+        WriteTimeout: s.config.Server.WriteTimeout.Duration(),
+        IdleTimeout:  s.config.Server.IdleTimeout.Duration(),
 	}
 
 	return srv.ListenAndServe()
@@ -61,12 +63,12 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Printf("🔥 PANIC in handleHealth: %v", err)
+            log.Printf("🔥 PANIC in handleRoot: %v", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 	}()
 
-	log.Printf("📝 Handling health request")
+    log.Printf("📝 Handling root request")
 	w.Write([]byte(`Bismarck Game Server v0.1.0`))
 
 }


### PR DESCRIPTION
Refactor duration parsing in config to correctly handle JSON values as seconds/hours, fixing server connection timeouts.

The original `time.Duration` fields in the config struct, when unmarshaled from JSON, interpreted bare numeric values (e.g., `30`) as nanoseconds instead of seconds, leading to extremely short server timeouts (30ns). This caused connections to close prematurely, making it seem like routes were not responding. This PR introduces custom `JSONDuration` and `JSONHours` types to correctly parse both string durations ("30s") and numeric values (interpreted as seconds or hours respectively), ensuring proper server and game timeout configurations. It also adds `IdleTimeout` and a logging middleware for improved server robustness and observability.

---
<a href="https://cursor.com/background-agent?bcId=bc-6aa676d3-4209-479e-8d5b-31b22f6e0bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6aa676d3-4209-479e-8d5b-31b22f6e0bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

